### PR TITLE
Remove extraneous warning

### DIFF
--- a/python/spinn/util/data.py
+++ b/python/spinn/util/data.py
@@ -221,8 +221,6 @@ def MakeTrainingIterator(sources, batch_size, smart_batches=True, use_peano=True
                 if len(batch) == batch_size:
                     batches.append(batch)
                     batch = []
-            if len(batch) > 0:
-                print "WARNING: May be discarding {} train examples.".format(len(batch))
         return batches
 
     def batch_iter():


### PR DESCRIPTION
Removing a few examples from the end of the dataset is pretty standard in SGD, and has little effect, since they get shuffled back in next epoch—no need for a warning.