### PR TITLE
Predict a binary value for each transition

### DIFF
--- a/python/spinn/models/supervised_classifier.py
+++ b/python/spinn/models/supervised_classifier.py
@@ -245,7 +245,10 @@ def train_loop(FLAGS, data_manager, model, optimizer, trainer,
             progress_bar.finish()
 
             A.add('total_loss', total_loss.data[0])
-            A.add('auxiliary_loss', aux_loss.data[0])
+            if isinstance(aux_loss, Variable):
+                A.add('auxiliary_loss', aux_loss.data[0])
+            else:
+                A.add('auxiliary_loss', 0.)
             A.add('xent_loss', xent_loss.data[0])
             A.add('l2_loss', l2_loss.data[0])
             stats_args = train_stats(model, optimizer, A, step)

--- a/python/spinn/rl_spinn.py
+++ b/python/spinn/rl_spinn.py
@@ -65,7 +65,7 @@ class RLSPINN(SPINN):
 
     def predict_actions(self, transition_output):
         transition_dist = F.sigmoid(
-                transition_output / max(self.temperature, 1e-8)).data.cpu()
+            transition_output / max(self.temperature, 1e-8)).data.cpu()
 
         if self.training:
             if self.catalan:
@@ -82,11 +82,13 @@ class RLSPINN(SPINN):
                 transition_dist = new_p
 
             shift_probs = transition_dist.numpy()
-            transition_preds = (np.random.rand(*shift_probs.shape) > shift_probs).astype('int32')
+            transition_preds = (np.random.rand(
+                *shift_probs.shape) > shift_probs).astype('int32')
         else:
             # Greedy prediction
             shift_probs = transition_dist
-            transition_preds = torch.round(1 - shift_probs).numpy().astype('int32')
+            transition_preds = torch.round(
+                1 - shift_probs).numpy().astype('int32')
         return transition_preds
 
 
@@ -233,10 +235,14 @@ class BaseModel(_BaseModel):
         # TODO: Many of these ops are on the cpu. Might be worth shifting to
         # GPU.
 
-        t_preds = np.concatenate([m['t_preds'] for m in self.spinn.memories if 't_preds' in m])
-        t_mask = np.concatenate([m['t_mask'] for m in self.spinn.memories if 't_mask' in m])
-        t_valid_mask = np.concatenate([m['t_valid_mask'] for m in self.spinn.memories if 't_mask' in m])
-        t_probs = torch.cat([m['t_probs'] for m in self.spinn.memories if 't_probs' in m], 0)
+        t_preds = np.concatenate([m['t_preds']
+                                  for m in self.spinn.memories if 't_preds' in m])
+        t_mask = np.concatenate([m['t_mask']
+                                 for m in self.spinn.memories if 't_mask' in m])
+        t_valid_mask = np.concatenate(
+            [m['t_valid_mask'] for m in self.spinn.memories if 't_mask' in m])
+        t_probs = torch.cat([m['t_probs']
+                             for m in self.spinn.memories if 't_probs' in m], 0)
 
         if self.rl_valid:
             t_mask = np.logical_and(t_mask, t_valid_mask)

--- a/python/spinn/util/loss.py
+++ b/python/spinn/util/loss.py
@@ -8,10 +8,11 @@ def auxiliary_loss(model):
     has_policy = has_spinn and hasattr(model, 'policy_loss')
     has_value = has_spinn and hasattr(model, 'value_loss')
 
-    total_loss = Variable(torch.Tensor([0.0]))
+    total_loss = 0
     if has_policy:
         total_loss += model.policy_loss
     if has_value:
         total_loss += model.value_loss
 
     return total_loss
+


### PR DESCRIPTION
Notable differences:

- Use sigmoid rather than log_softmax in many cases. This is because BCELoss applies the log for you.
- To get reduce probabilities, we do something like `(t_probs - t_preds).abs()`.
- To determine shift/reduce given probability, we do something like `(1 - t_probs).round()`. This is because probs represent the probability of shifting. This should probably be adjusted to simply round, aka should be probability of reducing.
- Entropy takes one additional step because it's not sufficient to sum like we used to.